### PR TITLE
[# 153839215] As Grand Rounds, so I don't have to open source my Stone software, figure out a way to remove `colorize` from it and do so.

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ['~> 2.0']
 
   spec.add_dependency "mime-types"
-  spec.add_dependency "colorize"
+  spec.add_dependency "rainbow"
   spec.add_dependency "open_uri_redirections"
   spec.add_dependency "activesupport"
   spec.add_dependency "addressable"

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -1,5 +1,5 @@
 require 'csvlint'
-require 'rainbow/refinement'
+require 'rainbow'
 require 'json'
 require 'pp'
 require 'thor'
@@ -8,7 +8,6 @@ require 'active_support/inflector'
 
 module Csvlint
   class Cli < Thor
-    using Rainbow
 
     desc "myfile.csv OR csvlint http://example.com/myfile.csv", "Supports validating CSV files to check their syntax and contents"
 
@@ -109,7 +108,7 @@ module Csvlint
         output_string += ". #{location}" unless location.empty?
         output_string += ". #{error.content}" if error.content
 
-        puts output_string.color(color)
+        puts Rainbow(output_string).color(color)
 
         if dump
           pp error
@@ -123,7 +122,7 @@ module Csvlint
       end
 
       def return_error(message)
-        puts message.red
+        puts Rainbow(message).red
         exit 1
       end
 
@@ -155,7 +154,7 @@ module Csvlint
           }.to_json
           print json
         else
-          puts "\r\n#{csv} is #{validator.valid? ? "VALID".green : "INVALID".red}"
+          puts "\r\n#{csv} is #{validator.valid? ? Rainbow("VALID").green : Rainbow("INVALID").red}"
           print_errors(validator.errors,   dump)
           print_errors(validator.warnings, dump)
         end
@@ -185,9 +184,9 @@ module Csvlint
         lambda do |row|
           new_errors = row.errors.count
           if new_errors > @error_count
-            print "!".red
+            print Rainbow("!").red
           else
-            print ".".green
+            print Rainbow(".").green
           end
           @error_count = new_errors
         end


### PR DESCRIPTION
As Grand Rounds, so I don't have to open source my Stone software, figure out a way to remove `colorize` from it and do so.

[Tracker #153839215](https://www.pivotaltracker.com/story/show/153839215)

This is also submitted as [PR#215](https://github.com/theodi/csvlint.rb/pull/215) in the original base fork, but we don't know when (or if) it'll be merged, so I want to make the changes available to `stone` (and `jarvis` if absolutely necessary) via the ConsultingMD fork.
  
Oh, and its CI system at that PR will show that it builds just fine :) No reason to configure a CI system for it here, yet.